### PR TITLE
Fix the result when a base dir starts with dot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/files
+/goxz

--- a/main.go
+++ b/main.go
@@ -46,6 +46,10 @@ func env(key, def string) string {
 
 type walkFn func(path string, info os.FileInfo) error
 
+func isHidden(cfg *config, path string) bool {
+	return cfg.hidden && cfg.base != path && filepath.Base(path)[0] == '.'
+}
+
 func makeWalkFn(cfg *config, processMatch walkFn) walkFn {
 	if cfg.directoryOnly {
 		return func(path string, info os.FileInfo) error {
@@ -53,7 +57,7 @@ func makeWalkFn(cfg *config, processMatch walkFn) walkFn {
 			if path == "." {
 				return nil
 			}
-			if cfg.hidden && filepath.Base(path)[0] == '.' {
+			if isHidden(cfg, path) {
 				if info.IsDir() {
 					return filepath.SkipDir
 				}
@@ -73,7 +77,7 @@ func makeWalkFn(cfg *config, processMatch walkFn) walkFn {
 		if path == "." {
 			return nil
 		}
-		if cfg.hidden && filepath.Base(path)[0] == '.' {
+		if isHidden(cfg, path) {
 			if info.IsDir() {
 				return filepath.SkipDir
 			}


### PR DESCRIPTION
dot dir や `..` を指定した場合に結果が得られません。

```
$ files .dir
$ files ..
```

探索対象の `path` が `base` と同じ場合は処理をスキップしないように変更しました。